### PR TITLE
feat: no tracking and let create-react-signals handle it

### DIFF
--- a/examples/01_typescript/src/App.tsx
+++ b/examples/01_typescript/src/App.tsx
@@ -4,7 +4,7 @@ import { proxy } from 'valtio/vanilla';
 import { useSnapshot } from 'valtio';
 import { $ } from 'valtio-signal';
 
-const state = proxy({ count: 0 });
+const state = proxy({ count: 0, text: 'hello' });
 
 const CounterWithSignal = () => {
   return (
@@ -30,6 +30,14 @@ const Controls = () => {
     <div>
       <button type="button" onClick={() => ++state.count}>
         Increment
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          state.text += '!';
+        }}
+      >
+        Change text
       </button>
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "create-react-signals": "0.5.0",
-    "proxy-compare": "2.4.0"
+    "create-react-signals": "https://pkg.csb.dev/dai-shi/create-react-signals/commit/f32bb44b/create-react-signals"
   },
   "devDependencies": {
     "@types/jest": "^29.2.5",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "create-react-signals": "https://pkg.csb.dev/dai-shi/create-react-signals/commit/f32bb44b/create-react-signals"
+    "create-react-signals": "0.6.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2780,9 +2780,10 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-"create-react-signals@https://pkg.csb.dev/dai-shi/create-react-signals/commit/f32bb44b/create-react-signals":
-  version "0.5.0"
-  resolved "https://pkg.csb.dev/dai-shi/create-react-signals/commit/f32bb44b/create-react-signals#68704adfeec904904b0997f2c9bf2c55dbeb5afd"
+create-react-signals@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/create-react-signals/-/create-react-signals-0.6.0.tgz#14aa9b2f35f88a1d474c12bf526e3c4f66294373"
+  integrity sha512-gATZDuVgecAckiP6e8QP37bkTxOEvhsB2OjOEWZ0jCOdKDPuHlNx1jMN9G5nwejJcFEyGiuEG6hfBTxv4Kw3XQ==
 
 cross-spawn@^6.0.5:
   version "6.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2780,10 +2780,9 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-create-react-signals@0.5.0:
+"create-react-signals@https://pkg.csb.dev/dai-shi/create-react-signals/commit/f32bb44b/create-react-signals":
   version "0.5.0"
-  resolved "https://registry.yarnpkg.com/create-react-signals/-/create-react-signals-0.5.0.tgz#d3ba12ad05e777bc2dfcb865adf769230af07f37"
-  integrity sha512-F7lefzsixWWKUXFD5/J227GwiVupdz9o7eAvDWpPHw8ZbGEi34hJh23Tq1i4sNEeHpoCllp+3MY342zfZ8lmmA==
+  resolved "https://pkg.csb.dev/dai-shi/create-react-signals/commit/f32bb44b/create-react-signals#68704adfeec904904b0997f2c9bf2c55dbeb5afd"
 
 cross-spawn@^6.0.5:
   version "6.0.5"


### PR DESCRIPTION
https://github.com/dai-shi/create-react-signals/pull/7

Now, tracking is handled upstream. code is simplified and extra proxies are eliminated.